### PR TITLE
Fix setup.py error and update build tests to use shared action

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -4,5 +4,5 @@ on:
   workflow_dispatch:
 
 jobs:
-  py_build_tests:
+  build_tests:
     uses: neongeckocom/.github/.github/workflows/python_build_tests.yml@master

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -4,33 +4,5 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
-      - name: Install Build Tools
-        run: |
-          python -m pip install build wheel
-      - name: Install System Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt install python3-dev swig libssl-dev libfann-dev portaudio19-dev libpulse-dev
-      - name: Build Source Packages
-        run: |
-          python setup.py sdist
-      - name: Build Distribution Packages
-        run: |
-          python setup.py bdist_wheel
-      - name: Install tflite_runtime workaround tflit bug
-        run: |
-          pip3 install numpy
-          pip3 install --extra-index-url https://google-coral.github.io/py-repo/ tflite_runtime
-      - name: Install core repo
-        run: |
-          pip install .[audio-backend,mark1,stt,tts,skills_minimal,skills,gui,bus,all]
+  py_build_tests:
+    uses: neongeckocom/.github/.github/workflows/python_build_tests.yml@master

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
     version=get_version(),
     description='silero VAD plugin for OpenVoiceOS',
     long_description=get_description(),
+    long_description_content_type="text/markdown",
     url='https://github.com/OpenVoiceOS/ovos-vad-plugin-silero',
     author='JarbasAi',
     author_email='jarbasai@mailfence.com',


### PR DESCRIPTION
Add missing `long_description_content_type` to setup.py
Use shared Build tests to catch build errors
[failure noted](https://github.com/OpenVoiceOS/ovos-vad-plugin-silero/actions/runs/9702776738/job/26779439616 ). Missed in https://github.com/OpenVoiceOS/ovos-vad-plugin-silero/pull/3