### PR TITLE
fix: onnxruntime version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ovos-plugin-manager>=0.0.11,<1.0.0
-onnxruntime
+onnxruntime<=1.20.1
 numpy<=1.26.4


### PR DESCRIPTION
avoid rpi breaking version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated a key dependency to restrict its version range, ensuring improved stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->