### PR TITLE
fix: requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ovos-plugin-manager>=0.0.11,<2.0.0
 onnxruntime<=1.22.2
-numpy<=1.26.4
+numpy<3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ovos-plugin-manager>=0.0.11,<2.0.0
-onnxruntime<=1.20.1
+onnxruntime<=1.22.2
 numpy<=1.26.4


### PR DESCRIPTION
allow newer onnxruntime versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Relaxed dependency constraints to support newer environments: onnxruntime is now allowed up to 1.22.2 and numpy constraint broadened (<3.0.0), improving compatibility and access to recent performance/stability fixes.
  - No changes to other pinned dependencies or public behavior; functionality remains unchanged.
  - To benefit from fixes, update your environment to pick up the newer packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->