### PR TITLE
fix: add publish_pypi: true to release workflow

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -18,5 +18,6 @@ jobs:
       version_file: 'ovos_vad_plugin_silero/version.py'
       update_changelog: true
       publish_prerelease: true
+      publish_pypi: true
       propose_release: true
       changelog_max_issues: 100


### PR DESCRIPTION
The shared `publish-alpha.yml` workflow defaults `publish_pypi` to `false` — it must be opted in explicitly. The previous PR left it unset so the PyPI publish step was skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflow configuration for improved release management processes.

---

*Note: This release contains no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->