### PR TITLE
chore: add missing shared CI workflows

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -1,10 +1,15 @@
-name: Run Build Tests
+name: Build Tests
+
 on:
   pull_request:
-    branches:
-      - dev
+    branches: [dev, master, main]
   workflow_dispatch:
 
 jobs:
-  build_tests:
+  build:
     uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
+    secrets: inherit
+    with:
+      python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      install_extras: 'test'
+      test_path: 'test'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,17 @@
+name: Code Coverage
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/coverage.yml@dev
+    secrets: inherit
+    with:
+      python_version: '3.11'
+      coverage_source: 'ovos_vad_plugin_silero'
+      test_path: 'test'
+      install_extras: '.[test]'
+      min_coverage: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [dev, master, main]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/lint.yml@dev
+    secrets: inherit
+    with:
+      ruff: true
+      pre_commit: false

--- a/.github/workflows/opm-check.yml
+++ b/.github/workflows/opm-check.yml
@@ -1,0 +1,21 @@
+name: OPM Plugin Check
+
+on:
+  pull_request:
+    branches: [dev, master, main]
+  workflow_dispatch:
+
+jobs:
+  opm_check:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/opm-check.yml@dev
+    secrets: inherit
+    with:
+      python_version: '3.11'
+      plugin_type: 'auto'
+      entry_point: ''
+      opm_require_found: true
+      opm_validate_interface: true
+      opm_test_import: true
+      opm_perf_threshold_ms: 500
+      opm_min_version: '2.2.3a1'
+      opm_max_version: '3.0.0'

--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -1,0 +1,11 @@
+name: PIP Audit
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  pip_audit:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/pip-audit.yml@dev
+    secrets: inherit

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,0 +1,14 @@
+name: Release Preview
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  release_preview:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/release-preview.yml@dev
+    secrets: inherit
+    with:
+      package_name: 'ovos_vad_plugin_silero'
+      version_file: 'ovos_vad_plugin_silero/version.py'

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -1,0 +1,13 @@
+name: Repo Health
+
+on:
+  pull_request:
+    branches: [dev, master, main]
+  workflow_dispatch:
+
+jobs:
+  repo_health:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/repo-health.yml@dev
+    secrets: inherit
+    with:
+      version_file: 'ovos_vad_plugin_silero/version.py'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,14 @@ classifiers = [
     "Topic :: Multimedia :: Sound/Audio :: Speech",
 ]
 dependencies = [
-    "ovos-plugin-manager>=2.1.0a1,<3.0.0",
+    "ovos-plugin-manager>=2.1.0,<3.0.0",
     "onnxruntime",
     "numpy<3.0.0",
 ]
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-cov"]
-test = ["pytest", "pytest-cov", "ovoscope"]
+test = ["pytest", "pytest-cov", "ovoscope<1.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-vad-plugin-silero"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,14 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-cov"]
-test = ["pytest", "pytest-cov", "ovoscope<1.0.0"]
+test = [
+    "pytest",
+    "pytest-cov",
+    # MiniVoiceLoop e2e tests need ovoscope.voice_loop (added in 0.19.1a2,
+    # which also fixes the pytest>=8 collection hook); not yet on PyPI.
+    "ovoscope @ git+https://github.com/TigreGotico/ovoscope@dev ; python_version >= '3.10'",
+    "ovos-dinkum-listener ; python_version >= '3.10'",
+]
 
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-vad-plugin-silero"


### PR DESCRIPTION
Adds the canonical OVOS shared reusable-workflow callers (referencing `OpenVoiceOS/gh-automations/.github/workflows/*@dev`).

Added:
- coverage
- lint
- pip-audit
- repo-health
- release-preview
- opm-check

Standardized the existing build-tests caller to the canonical form (python matrix + test inputs). Existing license-check, publish-alpha, publish-stable, and conventional-label callers were already `@dev` and left in place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated automated code coverage, linting, and dependency audit checks into the CI/CD pipeline.
  * Added plugin validation, repository health monitoring, and release preview automation.
  * Updated dependencies: relaxed plugin-manager requirement and constrained test dependency versions for stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->